### PR TITLE
make global time thread-safe and more fast

### DIFF
--- a/comet/tcp.go
+++ b/comet/tcp.go
@@ -137,7 +137,7 @@ func (server *Server) serveTCP(conn *net.TCPConn, rp, wp *bytes.Pool, tr *itime.
 		if err = p.ReadTCP(rr); err != nil {
 			break
 		}
-		p.Time = globalNowTime
+		p.Time = globalNow()
 		if p.Operation == define.OP_HEARTBEAT {
 			tr.Set(trd, hb)
 			p.Body = nil

--- a/comet/websocket.go
+++ b/comet/websocket.go
@@ -128,7 +128,7 @@ func (server *Server) serveWebsocket(conn *websocket.Conn, tr *itime.Timer) {
 		if err = p.ReadWebsocket(conn); err != nil {
 			break
 		}
-		p.Time = globalNowTime
+		p.Time = globalNow()
 		if p.Operation == define.OP_HEARTBEAT {
 			// heartbeat
 			tr.Set(trd, hb)


### PR DESCRIPTION
另外的一个建议就是把Proto中的Time字段直接使用int64（time.Now().UnixNano()）来表示，这样可以减少更多的转化损耗；如果觉得可行，我也可以在这个pr中一并改掉

