### PR TITLE
range variable bind captured by func literal

### DIFF
--- a/comet/websocket.go
+++ b/comet/websocket.go
@@ -45,12 +45,12 @@ func InitWebsocket(addrs []string) (err error) {
 		if Debug {
 			log.Debug("start websocket listen: \"%s\"", bind)
 		}
-		go func() {
+		go func(host string) {
 			if err = server.Serve(listener); err != nil {
-				log.Error("server.Serve(\"%s\") error(%v)", bind, err)
+				log.Error("server.Serve(\"%s\") error(%v)", host, err)
 				panic(err)
 			}
-		}()
+		}(bind)
 	}
 	return
 }
@@ -71,18 +71,18 @@ func InitWebsocketWithTLS(addrs []string, cert, priv string) (err error) {
 		if Debug {
 			log.Debug("start websocket wss listen: \"%s\"", bind)
 		}
-		go func() {
-			ln, err := net.Listen("tcp", bind)
+		go func(host string) {
+			ln, err := net.Listen("tcp", host)
 			if err != nil {
 				return
 			}
 
 			tlsListener := tls.NewListener(ln, config)
 			if err = server.Serve(tlsListener); err != nil {
-				log.Error("server.Serve(\"%s\") error(%v)", bind, err)
+				log.Error("server.Serve(\"%s\") error(%v)", host, err)
 				return
 			}
-		}()
+		}(bind)
 	}
 	return
 }


### PR DESCRIPTION
func main() {
    addrs := []string{
        "127.0.0.1:8888",
        "127.0.0.2:9999",
        "127.0.0.3:7777",
    }   

    wg := sync.WaitGroup{}
    for _, bind := range addrs {
        wg.Add(1)
        go func() {
            println(bind)
            wg.Done()
        }()
    }                                                                                                                                                                                                                                    
    wg.Wait()

}

func main() {
    addrs := []string{
        "127.0.0.1:8888",
        "127.0.0.2:9999",
        "127.0.0.3:7777",
    }   

    wg := sync.WaitGroup{}
    for _, bind := range addrs {
        wg.Add(1)
        go func(host string) {
            println(host)
            wg.Done()
        }(bind)
    }                                                                                                                                                                                                                                    
    wg.Wait()

}
