### PR TITLE
change default router config filename

### DIFF
--- a/router/config.go
+++ b/router/config.go
@@ -15,7 +15,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&confFile, "c", "./router-example.conf", " set router config file path")
+	flag.StringVar(&confFile, "c", "./router.conf", " set router config file path")
 }
 
 type Config struct {


### PR DESCRIPTION
Default config filename should be `router.conf` instead of `router-example.conf` for making consistent with `comet` and `logic`.