### PR TITLE
修复前端demo页alert对象错误

### DIFF
--- a/examples/javascript/demo.html
+++ b/examples/javascript/demo.html
@@ -11,7 +11,8 @@
     <script>
       var client = new MyClient({
         notify: function(data) {
-          alert(data);
+		  console.log(data);
+          alert(JSON.stringify(data));
         }
       });
     </script>


### PR DESCRIPTION
应该将得到的JSON数据stringify后再alert