### PR TITLE
部分错误修正并增加跨域

### DIFF
--- a/comet/config.go
+++ b/comet/config.go
@@ -65,7 +65,7 @@ type Config struct {
 	WebsocketPrivateFile string   `goconf:"websocket:private.file"`
 
 	//// socketio
-	SocketioBind        []string `goconf:"socketio:bind:,"`
+	SocketioBind        string `goconf:"socketio:bind:,"`
 	SocketioTrans       []string `goconf:"socketio:trans:,"`
 	SocketioTLSOpen     bool     `goconf:"socketio:tls.open"`
 	SocketioTLSBind     []string `goconf:"socketio:tls.bind:,"`

--- a/comet/config.go
+++ b/comet/config.go
@@ -65,7 +65,7 @@ type Config struct {
 	WebsocketPrivateFile string   `goconf:"websocket:private.file"`
 
 	//// socketio
-	SocketioBind        string `goconf:"socketio:bind:,"`
+	SocketioBind        []string `goconf:"socketio:bind:,"`
 	SocketioTrans       []string `goconf:"socketio:trans:,"`
 	SocketioTLSOpen     bool     `goconf:"socketio:tls.open"`
 	SocketioTLSBind     []string `goconf:"socketio:tls.bind:,"`
@@ -119,7 +119,7 @@ func NewConfig() *Config {
 		WebsocketPrivateFile: "../source/private.pem",
 
 		// socketio
-		SocketioBind: []string{"0.0.0.0:8088"},
+		SocketioBind: []string {"0.0.0.0:8088"},
 		SocketioTrans: []string{"websoket"},
 		// Socketio tls
 		SocketioTLSOpen:     false,

--- a/comet/socketio.go
+++ b/comet/socketio.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Initsocket.io listen all tcp.bind and start accept connections.
-func InitSocketIO(addrs []string, transport []string, accept string) (err error) {
+func InitSocketIO(addrs string, transport []string, accept string) (err error) {
 	server,err := socketio.NewServer(transport)
 	if(err != nil){
 		log.Warn("socketio init err")
@@ -53,7 +53,7 @@ func dispatchSocketIOEvent(server *socketio.Server,key string){
 }
 
 // auth for goim handshake with client, use rsa & aes.
-func (server *Server) authSocketio(ws *socketio.Conn, p *proto.Proto) (key string, rid int32, heartbeat time.Duration, err error) {
+func (server *Server) authSocketio(ws *socketio.Socket,, p *proto.Proto) (key string, rid int32, heartbeat time.Duration, err error) {
 	if err = p.ReadWebsocket(ws); err != nil {
 		return
 	}

--- a/comet/socketio.go
+++ b/comet/socketio.go
@@ -11,17 +11,19 @@ import (
 )
 
 // Initsocket.io listen all tcp.bind and start accept connections.
-func InitSocketIO(addrs string, transport []string, accept string) (err error) {
-	server,err := socketio.NewServer(transport)
-	if(err != nil){
-		log.Warn("socketio init err")
-	}
-	http.Handle("/socket.io/", server)
-	log.Info("socketio Serving at ",addrs)
-	http.ListenAndServe(addrs, nil)
-	key := accept
-	go dispatchSocketIOEvent(server,key)
-
+func InitSocketIO(addrs []string, transport []string, accept string) (err error) {
+	var bind string
+	for _, bind = range addrs {
+		server,err := socketio.NewServer(transport)
+	    if(err != nil){
+		    log.Warn("socketio init err")
+	    }
+		http.Handle("/socket.io/", server)
+	    log.Info("socketio Serving at ",bind)
+	    go http.ListenAndServe(bind, nil)
+	    key := accept
+	    go dispatchSocketIOEvent(server,key)
+		}
 	return err
 }
 

--- a/comet/socketio.go
+++ b/comet/socketio.go
@@ -18,7 +18,7 @@ func InitSocketIO(addrs string, transport []string, accept string) (err error) {
 	}
 	http.Handle("/socket.io/", server)
 	log.Info("socketio Serving at ",addrs)
-	http.ListenAndServe(addrs, nil))
+	http.ListenAndServe(addrs, nil)
 	key := accept
 	go dispatchSocketIOEvent(server,key)
 

--- a/comet/socketio.go
+++ b/comet/socketio.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Initsocket.io listen all tcp.bind and start accept connections.
-func InitSocketIO(addrs string, transport []string, accept string) (err error) {
+func InitSocketIO(addrs []string, transport []string, accept string) (err error) {
 	server,err := socketio.NewServer(transport)
 	if(err != nil){
 		log.Warn("socketio init err")
@@ -53,7 +53,7 @@ func dispatchSocketIOEvent(server *socketio.Server,key string){
 }
 
 // auth for goim handshake with client, use rsa & aes.
-func (server *Server) authSocketio(ws *socketio.Socket, p *proto.Proto) (key string, rid int32, heartbeat time.Duration, err error) {
+func (server *Server) authSocketio(ws *socketio.Conn, p *proto.Proto) (key string, rid int32, heartbeat time.Duration, err error) {
 	if err = p.ReadWebsocket(ws); err != nil {
 		return
 	}

--- a/comet/socketio.go
+++ b/comet/socketio.go
@@ -53,7 +53,7 @@ func dispatchSocketIOEvent(server *socketio.Server,key string){
 }
 
 // auth for goim handshake with client, use rsa & aes.
-func (server *Server) authSocketio(ws *socketio.Socket,, p *proto.Proto) (key string, rid int32, heartbeat time.Duration, err error) {
+func (server *Server) authSocketio(ws *socketio.Socket, p *proto.Proto) (key string, rid int32, heartbeat time.Duration, err error) {
 	if err = p.ReadWebsocket(ws); err != nil {
 		return
 	}

--- a/logic/config.go
+++ b/logic/config.go
@@ -50,6 +50,9 @@ type Config struct {
 	// kafka
 	KafkaTopic string   `goconf:"kafka:topic"`
 	KafkaAddrs []string `goconf:"kafka:addrs"`
+	//cors
+	CORSOpen bool `goconf:"cors:enable"`
+	CORSAddr []string `goconf:"cors:addr"`
 	// monitor
 	MonitorOpen  bool     `goconf:"monitor:open"`
 	MonitorAddrs []string `goconf:"monitor:addrs:,"`

--- a/logic/config.go
+++ b/logic/config.go
@@ -52,7 +52,7 @@ type Config struct {
 	KafkaAddrs []string `goconf:"kafka:addrs"`
 	//cors
 	CORSOpen bool `goconf:"cors:enable"`
-	CORSAddr []string `goconf:"cors:addr"`
+	CORSAddr string `goconf:"cors:addr"`
 	// monitor
 	MonitorOpen  bool     `goconf:"monitor:open"`
 	MonitorAddrs []string `goconf:"monitor:addrs:,"`

--- a/logic/http.go
+++ b/logic/http.go
@@ -76,6 +76,9 @@ func retPWrite(w http.ResponseWriter, r *http.Request, res map[string]interface{
 }
 
 func Push(w http.ResponseWriter, r *http.Request) {
+	if CORSOpen {
+		w.Header().Set("Access-Control-Allow-Origin", CORSAddr) 
+	}
 	if r.Method != "POST" {
 		http.Error(w, "Method Not Allowed", 405)
 		return
@@ -131,6 +134,9 @@ func parsePushsBody(body []byte) (msg []byte, userIds []int64, err error) {
 
 // {"m":{"test":1},"u":"1,2,3"}
 func Pushs(w http.ResponseWriter, r *http.Request) {
+	if CORSOpen {
+		w.Header().Set("Access-Control-Allow-Origin", CORSAddr) 
+	}
 	if r.Method != "POST" {
 		http.Error(w, "Method Not Allowed", 405)
 		return
@@ -169,6 +175,9 @@ func Pushs(w http.ResponseWriter, r *http.Request) {
 }
 
 func PushRoom(w http.ResponseWriter, r *http.Request) {
+	if CORSOpen {
+		w.Header().Set("Access-Control-Allow-Origin", CORSAddr) 
+	}
 	if r.Method != "POST" {
 		http.Error(w, "Method Not Allowed", 405)
 		return
@@ -206,6 +215,9 @@ func PushRoom(w http.ResponseWriter, r *http.Request) {
 }
 
 func PushAll(w http.ResponseWriter, r *http.Request) {
+	if CORSOpen {
+		w.Header().Set("Access-Control-Allow-Origin", CORSAddr) 
+	}
 	if r.Method != "POST" {
 		http.Error(w, "Method Not Allowed", 405)
 		return
@@ -244,6 +256,9 @@ type ServerCounter struct {
 }
 
 func Count(w http.ResponseWriter, r *http.Request) {
+	if CORSOpen {
+		w.Header().Set("Access-Control-Allow-Origin", CORSAddr) 
+	}
 	if r.Method != "GET" {
 		http.Error(w, "Method Not Allowed", 405)
 		return
@@ -270,6 +285,9 @@ func Count(w http.ResponseWriter, r *http.Request) {
 }
 
 func DelServer(w http.ResponseWriter, r *http.Request) {
+	if CORSOpen {
+		w.Header().Set("Access-Control-Allow-Origin", CORSAddr) 
+	}
 	if r.Method != "POST" {
 		http.Error(w, "Method Not Allowed", 405)
 		return

--- a/logic/logic-example.conf
+++ b/logic/logic-example.conf
@@ -83,6 +83,10 @@ log ./logic-log.xml
 topic KafkaPushsTopic
 addrs 127.0.0.1:9092,127.0.0.2:9092
 
+[cors]
+enable false
+addr *
+
 [monitor]
 # monitor listen
 open true


### PR DESCRIPTION
1.修复socketio.go内符号和一个变量导致的编译错误，但仍无法编译
2.增加xhr跨域功能，并在配置文件中增加选项