### PR TITLE
fix min heap up operation

### DIFF
--- a/pkg/time/timer.go
+++ b/pkg/time/timer.go
@@ -227,7 +227,7 @@ func (t *Timer) expire() {
 func (t *Timer) up(j int) {
 	for {
 		i := (j - 1) / 2 // parent
-		if i <= j || !t.less(j, i) {
+		if i == j || !t.less(j, i) {
 			break
 		}
 		t.swap(i, j)


### PR DESCRIPTION
在堆调整的时候，不断比较子节点和父节点，直到子节点不在小于父节点，或者子节点和父节点一致了

```
func (t *Timer) up(j int) {
	for {
		i := (j - 1) / 2 // parent
		if i == j || !t.less(j, i) {
			break
		}
		t.swap(i, j)
		j = i
	}
}
```