### PR TITLE
修复web websocket client push命令demo的格式错误

### DIFF
--- a/examples/javascript/index.html
+++ b/examples/javascript/index.html
@@ -23,9 +23,9 @@
     <span id="status"></span>
     <h2>push</h2>
     <div>
-        <p>curl -d 'mid message' http://api.goim.io:3111/goim/push/mids?operation=1000&mids=123</p>
-        <p>curl -d 'room message' http://api.goim.io:3111/goim/push/room?operation=1000&type=live&room=1000</p>
-        <p>curl -d 'broadcast message' http://api.goim.io:3111/goim/push/all?operation=1000</p>
+        <p>curl -d 'mid message' 'http://api.goim.io:3111/goim/push/mids?operation=1000&mids=123'</p>
+        <p>curl -d 'room message' 'http://api.goim.io:3111/goim/push/room?operation=1000&type=live&room=1000'</p>
+        <p>curl -d 'broadcast message' 'http://api.goim.io:3111/goim/push/all?operation=1000'</p>
     </div>
     <h2>message:</h2>
     <div id="box"></div>


### PR DESCRIPTION
原本example中的web websocket client 中，push 命令中的url没有使用引号，会导致&后面的内容传递失败

![image](https://user-images.githubusercontent.com/3816205/116550433-59c88980-a929-11eb-81c0-d1e3c7f070d6.png)
