### PR TITLE
fix(comet): dirty reads will occur when serve conn is concurrent

### DIFF
--- a/internal/comet/server_tcp.go
+++ b/internal/comet/server_tcp.go
@@ -49,12 +49,11 @@ func InitTCP(server *Server, addrs []string, accept int) (err error) {
 // invokes it in a go statement.
 func acceptTCP(server *Server, lis *net.TCPListener) {
 	var (
-		conn *net.TCPConn
-		err  error
-		r    int
+		r int
 	)
 	for {
-		if conn, err = lis.AcceptTCP(); err != nil {
+		conn, err := lis.AcceptTCP()
+		if err != nil {
 			// if listener close then return
 			log.Errorf("listener.Accept(\"%s\") error(%v)", lis.Addr().String(), err)
 			return

--- a/internal/comet/server_websocket.go
+++ b/internal/comet/server_websocket.go
@@ -80,12 +80,11 @@ func InitWebsocketWithTLS(server *Server, addrs []string, certFile, privateFile 
 // invokes it in a go statement.
 func acceptWebsocket(server *Server, lis *net.TCPListener) {
 	var (
-		conn *net.TCPConn
-		err  error
-		r    int
+		r int
 	)
 	for {
-		if conn, err = lis.AcceptTCP(); err != nil {
+		conn, err := lis.AcceptTCP()
+		if err != nil {
 			// if listener close then return
 			log.Errorf("listener.Accept(%s) error(%v)", lis.Addr().String(), err)
 			return


### PR DESCRIPTION
当客户端并发连接时，会出现多个goroutine读取到同一个conn对象的情况